### PR TITLE
Enables newFileAddsNewToQuery option in CFM UI [#162022225]

### DIFF
--- a/src/code/index.tsx
+++ b/src/code/index.tsx
@@ -85,7 +85,8 @@ const options = {
           window.location.search = queryString.stringify(newParams);
         }
       }
-    }
+    },
+    newFileAddsNewToQuery: true
   },
 };
 


### PR DESCRIPTION
This is used to know when to show the create/open dialog after the splash screen.

The code already exists to not show that dialog if there is a hash parameter (such as a file in the url)