### PR TITLE
Add di-override parameter to CODAP to allow sage url parameters to override saved urls [#162703673]

### DIFF
--- a/src/code/codap-iframe-src.ts
+++ b/src/code/codap-iframe-src.ts
@@ -44,7 +44,7 @@ const iframeSrc = (options: CodapParamsOptions) => {
   });
 
   const diParams = encodeURIComponent(`?${stringify(sageParams)}`);
-  return `${codap}?${stringify(codapParams)}&di=${di}${diParams}`;
+  return `${codap}?${stringify(codapParams)}&di=${di}${diParams}&di-override=${di}`;
 };
 
 export const codapIframeSrc = iframeSrc({


### PR DESCRIPTION
If the di-override parameter is present CODAP will search and replace the url matching that parameter with the di paramter passed to CODAP.