### PR TITLE
Change di-override to just use the string "sage"

### DIFF
--- a/src/code/codap-iframe-src.ts
+++ b/src/code/codap-iframe-src.ts
@@ -44,7 +44,7 @@ const iframeSrc = (options: CodapParamsOptions) => {
   });
 
   const diParams = encodeURIComponent(`?${stringify(sageParams)}`);
-  return `${codap}?${stringify(codapParams)}&di=${di}${diParams}&di-override=${di}`;
+  return `${codap}?${stringify(codapParams)}&di=${di}${diParams}&di-override=sage`;
 };
 
 export const codapIframeSrc = iframeSrc({


### PR DESCRIPTION
This will also files saved with different branches of sage to be overridden  - before it was trying for an exact match of the di url.