### PR TITLE
Removed <DOCTYPE html> due to CFM dialog layout issues [#161082471]

### DIFF
--- a/src/templates/index.html.ejs
+++ b/src/templates/index.html.ejs
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title>SageModeler</title>


### PR DESCRIPTION
This reverts an earlier commit to add the doctype type to fix dialog centering isseus.