### PR TITLE
View view work link [#167814843]

### DIFF
--- a/src/code/index.tsx
+++ b/src/code/index.tsx
@@ -15,9 +15,9 @@ try {
   inIframe = false;
 }
 
-// the two ways we detect if we are launched from lara is if we are in an iframe
-// or there is a documentServer parameter that is part of the LARA embed parameters
-const launchedFromLara = inIframe || !!parsedParams.documentServer;
+// the three ways we detect if we are launched from lara is if we are in an iframe
+// or there is either a documentServer or launchFromLara parameter that is part of the LARA embed parameters
+const launchedFromLara = inIframe || !!parsedParams.documentServer || !!parsedParams.launchFromLara;
 
 const selfUrl = `${window.location.origin}${window.location.pathname}`;
 


### PR DESCRIPTION
Fixed when opening SageModeler using "view work" link on the portal teacher report, the Open/New dialog is displayed over the saved model.