### PR TITLE
Added inbounds parameter to CODAP iframe

### DIFF
--- a/src/code/codap-iframe-src.ts
+++ b/src/code/codap-iframe-src.ts
@@ -39,6 +39,7 @@ const iframeSrc = (options: CodapParamsOptions) => {
     hideSplashScreen: "yes",
     hideWebViewLoading: "yes",
     hideUndoRedoInComponent: "yes",
+    inbounds: "true",
     cfmBaseUrl
   };
   const sageParams = {


### PR DESCRIPTION
This tells CODAP to try to keep the visual components within the window as it is resized.