### PR TITLE
Change s3 deploy action to pin Ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   s3-deploy:
     name: S3 Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
The ubuntu-latest now doesn't have Ruby 2.4 which is needed for the s3 deploy action.