### PR TITLE
Added disableHostCheck to webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,9 @@ module.exports = (env, argv) => {
       devtool: 'source-map',
       entry: './src/code/index.tsx',
       mode: 'development',
+      devServer: {
+        disableHostCheck: true,
+      },
       output: {
         path: __dirname + (devMode ? "/dev" : "/dist"),
         filename: 'app/js/app.js'


### PR DESCRIPTION
This was needed after webpack was upgraded, otherwise the devserver websocket threw an error when proxied