### PR TITLE
Added disableSharedDrives option [#183168207]

### DIFF
--- a/src/code/index.tsx
+++ b/src/code/index.tsx
@@ -47,7 +47,8 @@ const providers = [
       "https://www.googleapis.com/auth/drive.install",
       "https://www.googleapis.com/auth/drive.metadata.readonly",
       "https://www.googleapis.com/auth/userinfo.profile"
-    ]
+    ],
+    "disableSharedDrives": true
   },
   {
     "name": "documentStore",


### PR DESCRIPTION
This is needed for the Google Drive API v3 cutover as the SageModeler app doesn't have the required access rights to list shared drives.