### PR TITLE
fix: Fix export of tables and graphs [PT-175219669]

### DIFF
--- a/src/code/codap-iframe-src.ts
+++ b/src/code/codap-iframe-src.ts
@@ -36,7 +36,8 @@ const iframeSrc = (options: CodapParamsOptions) => {
     hideWebViewLoading: "yes",
     hideUndoRedoInComponent: "yes",
     "lang-override": lang,
-    inbounds: "true"
+    inbounds: "true",
+    saveSecondaryFileViaPostMessage: "true"
   };
   const sageParams = {
     standalone: "true"

--- a/src/code/index.tsx
+++ b/src/code/index.tsx
@@ -192,6 +192,15 @@ CloudFileManager.createFrame(options, "app", event => {
       }
     });
 
+    window.addEventListener("message", (e) => {
+      // This message is sent by CODAP's CFM due to the saveSecondaryFileViaPostMessage
+      // being set as a CODAP query parameter in codap-iframe-src.ts.
+      if (e.data.action === "saveSecondaryFile") {
+        const {extension, mimeType, content} = e.data;
+        client.saveSecondaryFileAsDialog(content, extension, mimeType);
+      }
+    });
+
     (window as any).onSplashScreenClosed = () => {
       // only show the open or create if there is no hash parameter (for loading a file)
       // and we are not in an iframe (for LARA) or were launched from LARA


### PR DESCRIPTION
This adds a query parameter to CODAP that the CFM already looks for that causes CODAP exports to post a message with the contents and mimetype to export to the parent window.

The missing part on the SageModeler side (the parent window) was to add an event listener to cause the top level SageModeler CFM to show the export dialog.