### PR TITLE
feat: Removed restricted drive.metadata.readonly scope

### DIFF
--- a/src/code/index.tsx
+++ b/src/code/index.tsx
@@ -46,7 +46,6 @@ const providers = [
     "scopes": [
       "https://www.googleapis.com/auth/drive.file",
       "https://www.googleapis.com/auth/drive.install",
-      "https://www.googleapis.com/auth/drive.metadata.readonly",
       "https://www.googleapis.com/auth/userinfo.profile"
     ],
     "disableSharedDrives": true


### PR DESCRIPTION
This removes the now unneeded restricted scope with the switch to the Google Drive picker.