### PR TITLE
refactor: Switch CODAP v2 launch path from /releases/ to /v2/ [SM-14]

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ where those projects are deployed.  This enables this project to be tested again
 
 The parameters are:
 
-- ?codap=<`URL`|`release`> where `URL` is the url to the CODAP index.html page or `release` is the CODAP release folder (example: `build_0473`)
+- ?codap=<`URL`|`branch`> where `URL` is the url to the CODAP index.html page (works for both v2 and v3) or `branch` is the name of a CODAP v3 branch deployed to `/codap3/branch/<branch>/`. For CODAP v2 the bare-name shortcut is no longer meaningful - v2 always loads through `/v2/` regardless of the value passed; use the full-URL form (`?codap=https://...`) for any one-off v2-build testing.
 - ?di=<`URL`|`branch`> where `URL` is the url to Sage (di is passed to CODAP, it stands for "data interactive") or `branch` is the deployed Sage branch (example: `164295027-default-to-zero`)
 - ?cfmBaseUrl=<`URL`|`branch`> where `URL` is the url to the /js folder for CFM or `branch` is the deployed CFM branch (example: `fix-example-loads-in-codap`).  In order to allow for testing of separate CFM instances in sage-modeler-site, CODAP and building-models you must explicitly also override their cfmBaseUrl's by using either the `codap:` or `sage:` prefix.  Here is an example url that overrides all the CFMs:  https://sagemodeler.concord.org/app/?cfmBaseUrl=add-persistent-saves&sage:cfmBaseUrl=add-persistent-saves&codap:cfmBaseUrl=add-persistent-saves
 

--- a/src/code/codap-iframe-src.ts
+++ b/src/code/codap-iframe-src.ts
@@ -36,7 +36,7 @@ const iframeSrc = (options: CodapParamsOptions) => {
     const codapPrefix = options.codap.replace(/\/index\.html$/, "");
     codap = expandBranchUrl(codap, `${codapPrefix}/branch/${codap}/`);
   } else {
-    codap = expandBranchUrl(codap, `/releases/${codap}/static/dg/${lang}/cert/`);
+    codap = expandBranchUrl(codap, `/v2/static/dg/${lang}/cert/`);
   }
   di =  expandBranchUrl(di, `/sage/branch/${di}/sagemodeler.html`);
   cfmBaseUrl = expandBranchUrl(cfmBaseUrl, `/cfm/branch/${cfmBaseUrl}/js`);

--- a/src/code/codap-iframe-src.ts
+++ b/src/code/codap-iframe-src.ts
@@ -36,6 +36,8 @@ const iframeSrc = (options: CodapParamsOptions) => {
     const codapPrefix = options.codap.replace(/\/index\.html$/, "");
     codap = expandBranchUrl(codap, `${codapPrefix}/branch/${codap}/`);
   } else {
+    // v2 ignores short ?codap= values (no per-build routing post-v3-cutover);
+    // bare names always expand to the stable /v2/ path. Full-URL overrides still work.
     codap = expandBranchUrl(codap, `/v2/static/dg/${lang}/cert/`);
   }
   di =  expandBranchUrl(di, `/sage/branch/${di}/sagemodeler.html`);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = (env, argv) => {
         cfmUrl = devMode ? "/cfm" : "/cfm",
         codapUrl = devMode
           ? (isV3 ? "/codap/index.html" : "/codap/static/dg/en/cert/index.html")
-          : (isV3 ? "/codap3/index.html" : "/releases/stable/static/dg/en/cert/index.html"),
+          : (isV3 ? "/codap3/index.html" : "/v2/static/dg/en/cert/index.html"),
         sageUrl = devMode ? "/sage" : "/sage";
 
   return [


### PR DESCRIPTION
Production v2 launches now load from /v2/static/dg/en/cert/index.html instead of /releases/stable/..., matching the explicit /v2/ semantics served by the new sagemodeler.concord.org CloudFront behavior.

- webpack.config.js: prod v2 codapUrl points at /v2/
- codap-iframe-src.ts: v2 branch-name shortcut now resolves to /v2/ (drops ${codap} interpolation — specific historical v2 builds are no longer a testing target; full-URL ?codap= form still works)
- README: update QA ?codap= docs to reflect the new behavior

---

**Test url**: https://sagemodeler.concord.org/branch/use-v2-url/app/